### PR TITLE
road_flipped_problem fix by adding minus to Z in g2o optimizer

### DIFF
--- a/apps/hdl_graph_slam_nodelet.cpp
+++ b/apps/hdl_graph_slam_nodelet.cpp
@@ -423,7 +423,7 @@ private:
 
       if(enable_imu_acceleration) {
         Eigen::MatrixXd info = Eigen::MatrixXd::Identity(3, 3) / imu_acceleration_edge_stddev;
-        g2o::OptimizableGraph::Edge* edge = graph_slam->add_se3_prior_vec_edge(keyframe->node, Eigen::Vector3d::UnitZ(), *keyframe->acceleration, info);
+        g2o::OptimizableGraph::Edge* edge = graph_slam->add_se3_prior_vec_edge(keyframe->node, -Eigen::Vector3d::UnitZ(), *keyframe->acceleration, info);
         graph_slam->add_robust_kernel(edge, private_nh.param<std::string>("imu_acceleration_edge_robust_kernel", "NONE"), private_nh.param<double>("imu_acceleration_edge_robust_kernel_size", 1.0));
       }
       updated = true;


### PR DESCRIPTION
I opened https://github.com/koide3/hdl_graph_slam/issues/66 and changed the sign of "Eigen::Vector3d::UnitZ()" as your advice. After catkin_make, it works well now.

You can see the test video here. Link : https://www.youtube.com/watch?v=jkRPvn1jEkM&feature=youtu.be

Best.