### PR TITLE
Fix ros-kinetic-pcl-ros typo inside readme :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following ROS packages are required:
 # for indigo
 sudo apt-get install ros-indigo-geodesy ros-indigo-pcl_ros ros-indigo-nmea-msgs
 # for kinetic
-sudo apt-get install ros-kinetic-geodesy ros-kinetic-pcl_ros ros-kinetic-nmea-msgs ros-kinetic-libg2o
+sudo apt-get install ros-kinetic-geodesy ros-kinetic-pcl-ros ros-kinetic-nmea-msgs ros-kinetic-libg2o
 # for melodic
 sudo apt-get install ros-melodic-geodesy ros-melodic-pcl-ros ros-melodic-nmea-msgs ros-melodic-libg2o
 


### PR DESCRIPTION
On the installation guide inside the readme 
the package name was misspell