### PR TITLE
Fix RadiusOutlierRemoval not applied

### DIFF
--- a/apps/prefiltering_nodelet.cpp
+++ b/apps/prefiltering_nodelet.cpp
@@ -76,6 +76,7 @@ private:
       pcl::RadiusOutlierRemoval<PointT>::Ptr rad(new pcl::RadiusOutlierRemoval<PointT>());
       rad->setRadiusSearch(radius);
       rad->setMinNeighborsInRadius(min_neighbors);
+      outlier_removal_filter = rad;
     } else {
       std::cout << "outlier_removal: NONE" << std::endl;
     }


### PR DESCRIPTION
I noticed that the radius outlier removal was not applied to the input cloud. This patch enables it.