### PR TITLE
WIP: Use TF2 for TF broadcasters and listeners

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   tf2
   tf2_ros
+  tf2_geometry_msgs
   tf2_eigen
   message_generation
   interactive_markers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@ find_package(catkin REQUIRED COMPONENTS
   geodesy
   nmea_msgs
   sensor_msgs
+  tf2
+  tf2_ros
+  tf2_eigen
   message_generation
   interactive_markers
   ndt_omp

--- a/apps/hdl_graph_slam_nodelet.cpp
+++ b/apps/hdl_graph_slam_nodelet.cpp
@@ -17,6 +17,7 @@
 #include <pcl_ros/point_cloud.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>

--- a/apps/scan_matching_odometry_nodelet.cpp
+++ b/apps/scan_matching_odometry_nodelet.cpp
@@ -5,8 +5,8 @@
 #include <ros/time.h>
 #include <ros/duration.h>
 #include <pcl_ros/point_cloud.h>
-#include <tf_conversions/tf_eigen.h>
-#include <tf/transform_broadcaster.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 #include <std_msgs/Time.h>
 #include <nav_msgs/Odometry.h>
@@ -234,8 +234,8 @@ private:
   ros::Subscriber points_sub;
 
   ros::Publisher odom_pub;
-  tf::TransformBroadcaster odom_broadcaster;
-  tf::TransformBroadcaster keyframe_broadcaster;
+  tf2_ros::TransformBroadcaster odom_broadcaster;
+  tf2_ros::TransformBroadcaster keyframe_broadcaster;
 
   std::string points_topic;
   std::string odom_frame_id;

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,9 @@
   <build_depend>geodesy</build_depend>
   <build_depend>nmea_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_eigen</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>libg2o</build_depend>
 
@@ -26,6 +29,9 @@
   <run_depend>nodelet</run_depend>
   <run_depend>nmea_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_eigen</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_eigen</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>libg2o</build_depend>
@@ -31,6 +32,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>tf2_eigen</run_depend>
 
   <export>


### PR DESCRIPTION
From the wiki (http://wiki.ros.org/tf2/Migration#tf_and_tf2),

> Since ROS Hydro, tf has been "deprecated" in favor of tf2.

Actually, the reason why I submitted this PR is because I'm planning on writing a nodelet that listens to transformations between `odom` and `base_link` and use that to create keyframes instead of the `scan_matching_odometry_nodelet`. For that, I felt like using TF2 instead of TF1 is better. However, if you think this change introduces more risk of breakage than benefits, feel free to close this PR!

Edit 1: Please put this PR on hold because I am experiencing TF exceptions.

Edit 2: The TF exceptions may be due to the fact that I'm using a custom-built PCL (because I'm currently on kinetic). I'll look into this issue.