### PR TITLE
Publishing aligned point cloud if subscribed, fixed use of map_cloud_resolution

### DIFF
--- a/apps/hdl_graph_slam_nodelet.cpp
+++ b/apps/hdl_graph_slam_nodelet.cpp
@@ -518,7 +518,7 @@ private:
     snapshot = keyframes_snapshot;
     keyframes_snapshot_mutex.unlock();
 
-    auto cloud = map_cloud_generator->generate(snapshot, 0.05);
+    auto cloud = map_cloud_generator->generate(snapshot, map_cloud_resolution);
     if(!cloud) {
       return;
     }

--- a/apps/scan_matching_odometry_nodelet.cpp
+++ b/apps/scan_matching_odometry_nodelet.cpp
@@ -52,6 +52,7 @@ public:
     read_until_pub = nh.advertise<std_msgs::Header>("/scan_matching_odometry/read_until", 32);
     odom_pub = nh.advertise<nav_msgs::Odometry>("/odom", 32);
     trans_pub = nh.advertise<geometry_msgs::TransformStamped>("/scan_matching_odometry/transform", 32);
+    aligned_points_pub = nh.advertise<sensor_msgs::PointCloud2>("/aligned_points", 32);
   }
 
 private:
@@ -223,6 +224,13 @@ private:
       keyframe_stamp = stamp;
       prev_trans.setIdentity();
     }
+    
+    if (aligned_points_pub.getNumSubscribers() > 0)
+    {
+      pcl::transformPointCloud (*cloud, *aligned, odom);
+      aligned->header.frame_id=odom_frame_id;
+      aligned_points_pub.publish(aligned);
+    }
 
     return odom;
   }
@@ -269,6 +277,7 @@ private:
 
   ros::Publisher odom_pub;
   ros::Publisher trans_pub;
+  ros::Publisher aligned_points_pub;
   tf::TransformBroadcaster odom_broadcaster;
   tf::TransformBroadcaster keyframe_broadcaster;
 

--- a/src/hdl_graph_slam/map_cloud_generator.cpp
+++ b/src/hdl_graph_slam/map_cloud_generator.cpp
@@ -33,6 +33,9 @@ pcl::PointCloud<MapCloudGenerator::PointT>::Ptr MapCloudGenerator::generate(cons
   cloud->height = 1;
   cloud->is_dense = false;
 
+  if (resolution <=0.0)
+    return cloud; // To get unfiltered point cloud with intensity
+
   pcl::octree::OctreePointCloud<PointT> octree(resolution);
   octree.setInputCloud(cloud);
   octree.addPointsFromInputCloud();


### PR DESCRIPTION
Publishing aligned point cloud helps debug pointcloud registration issue in local slam.
These point clouds could also be accumulated in the odom frame to produce a denser pointcloud useful in some applications.

map_cloud_generator had a fixed resolution of 0.05 and param `map_cloud_resolution` was never used for anything. I gues this param was meant to be used for map_cloud_generator.

For resolution of 0.0 or less I am bypassing the filter. That way I am also able to preserve intensitety values in the final point cloud. Currently OctreePointCloud does not keep intensities.

