### PR TITLE
Fixed formatting UTM origin coordinates in second save function

### DIFF
--- a/apps/hdl_graph_slam_nodelet.cpp
+++ b/apps/hdl_graph_slam_nodelet.cpp
@@ -880,7 +880,7 @@ private:
 
     if(zero_utm) {
       std::ofstream ofs(req.destination + ".utm");
-      ofs << (*zero_utm).transpose() << std::endl;
+      ofs << boost::format("%.6f %.6f %.6f") % zero_utm->x() % zero_utm->y() % zero_utm->z() << std::endl;
     }
 
     int ret = pcl::io::savePCDFileBinary(req.destination, *cloud);


### PR DESCRIPTION
This is the same fix as in https://github.com/koide3/hdl_graph_slam/commit/63412b459abff5ccd4f27b90c085c8c2fc9fdc9d just applied to the second save function.
