### PR TITLE
Include missing boost/optional.hpp

### DIFF
--- a/apps/floor_detection_nodelet.cpp
+++ b/apps/floor_detection_nodelet.cpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <iostream>
 
+#include <boost/optional.hpp>
+
 #include <ros/ros.h>
 #include <ros/time.h>
 #include <pcl_ros/point_cloud.h>


### PR DESCRIPTION
Fix this particular error that only happen in newer boost 
```
/home/toni/Documents/ros_ws/hdl/src/hdl_graph_slam/apps/floor_detection_nodelet.cpp:108:10: error: ‘optional’ in namespace ‘boost’ does not name a template type; did you mean ‘conditional’?
  108 |   boost::optional<Eigen::Vector4f> detect(const pcl::PointCloud<PointT>::Ptr& cloud) const {
      |          ^~~~~~~~
      |          conditional
/home/toni/Documents/ros_ws/hdl/src/hdl_graph_slam/apps/floor_detection_nodelet.cpp: In member function ‘void hdl_graph_slam::FloorDetectionNodelet::cloud_callback(const PointCloud2ConstPtr&)’:
/home/toni/Documents/ros_ws/hdl/src/hdl_graph_slam/apps/floor_detection_nodelet.cpp:79:12: error: ‘optional’ is not a member of ‘boost’; did you mean ‘conditional’?
   79 |     boost::optional<Eigen::Vector4f> floor = detect(cloud);
      |            ^~~~~~~~
      |            conditional
/home/toni/Documents/ros_ws/hdl/src/hdl_graph_slam/apps/floor_detection_nodelet.cpp:79:36: error: expected primary-expression before ‘>’ token
   79 |     boost::optional<Eigen::Vector4f> floor = detect(cloud);
      |                                    ^
/home/toni/Documents/ros_ws/hdl/src/hdl_graph_slam/apps/floor_detection_nodelet.cpp:79:46: error: ‘detect’ was not declared in this scope; did you mean ‘select’?
   79 |     boost::optional<Eigen::Vector4f> floor = detect(cloud);
      |                                              ^~~~~~
      |                                              select
/home/toni/Documents/ros_ws/hdl/src/hdl_graph_slam/apps/floor_detection_nodelet.cpp:84:13: error: cannot resolve overloaded function ‘floor’ based on conversion to type ‘bool’
   84 |     if(floor) {
      |             ^
/home/toni/Documents/ros_ws/hdl/src/hdl_graph_slam/apps/floor_detection_nodelet.cpp:87:30: error: overloaded function with no contextual type information
   87 |         coeffs.coeffs[i] = (*floor)[i];

```