### PR TITLE
Install hdl_graph_slam's header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,3 +153,7 @@ install(TARGETS
   scan_matching_odometry_nodelet 
   hdl_graph_slam_nodelet
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+install(DIRECTORY include/
+   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+)


### PR DESCRIPTION
The interactive_slam needs some hdl_graph_slam header definition. The end result will be :
```
        └── ros
            └── noetic
                ├── include
                │   ├── g2o
                │   │   ├── edge_plane_identity.hpp
                │   │   ├── edge_plane_parallel.hpp
                │   │   ├── edge_plane_prior.hpp
                │   │   ├── edge_se3_plane.hpp
                │   │   ├── edge_se3_priorquat.hpp
                │   │   ├── edge_se3_priorvec.hpp
                │   │   ├── edge_se3_priorxy.hpp
                │   │   ├── edge_se3_priorxyz.hpp
                │   │   └── robust_kernel_io.hpp
                │   └── hdl_graph_slam
                │       ├── DumpGraph.h
                │       ├── DumpGraphRequest.h
                │       ├── DumpGraphResponse.h
                │       ├── FloorCoeffs.h
                │       ├── graph_slam.hpp
                │       ├── information_matrix_calculator.hpp
                │       ├── keyframe.hpp
                │       ├── keyframe_updater.hpp
                │       ├── loop_detector.hpp
                │       ├── map_cloud_generator.hpp
                │       ├── nmea_sentence_parser.hpp
                │       ├── registrations.hpp
                │       ├── ros_time_hash.hpp
                │       ├── ros_utils.hpp
                │       ├── SaveMap.h
                │       ├── SaveMapRequest.h
                │       ├── SaveMapResponse.h
                │       └── ScanMatchingStatus.h
```
We are lucky that these header doesn't conflict with header from ros-noetic-libg2o