### PR TITLE
Add missing eigen header when compile interactive-slam with original g2o

### DIFF
--- a/include/hdl_graph_slam/graph_slam.hpp
+++ b/include/hdl_graph_slam/graph_slam.hpp
@@ -7,6 +7,7 @@
 #include <ros/time.h>
 
 #include <g2o/core/hyper_graph.h>
+#include <Eigen/Dense>
 
 namespace g2o {
 class VertexSE3;


### PR DESCRIPTION
Hello
This PR for fix eigen error when we compile interactive-slam with original g2o instead of use libg2o from ROS.
Because libg2o from ROS doesn't use latest commit from original g2o source code. After I integrated original g2o from source  and compiled my workspace. **hdl_graph_slam** appeared this error:
![image](https://user-images.githubusercontent.com/48971289/189467187-05f190b3-cebe-4e5d-9066-9ce5f0702ab3.png)
And I fixed this problem by adding this line `#include <Eigen/Dense>` in **graph_slam.hpp**
